### PR TITLE
Fix http/1.0 detection & zero pad header count

### DIFF
--- a/ja4h.lua
+++ b/ja4h.lua
@@ -34,6 +34,8 @@ local function http_version(txn)
         return '30'
     elseif (v == '2.0') then
         return '20'
+    elseif (v == '1.0') then
+        return '10'
     else
         return '11'
     end

--- a/ja4h.lua
+++ b/ja4h.lua
@@ -51,7 +51,13 @@ local function header_count(txn)
             c = c + 1
         end
     end
-    return c
+    if (c >= 99) then
+        return '99'
+    end
+    if (c < 10) then
+        return '0' .. c
+    end
+    return tostring(c)
 end
 
 local function referer_is_set(txn)


### PR DESCRIPTION
Hi,
I noticed this ja4h implementation does not zero pad the header count and also does not detect http/1.0 correctly. This PR fixes both issues, to align it with other implementations.

The python implementation which is referenced in the code also had the http/1.0 bug and was patched recently see:
https://github.com/FoxIO-LLC/ja4/commit/3c71e523dd4eb522a98bdd66def9a45d35b85ad6

In the tests there you can also find some examples that the header count should be zero padded:
https://github.com/FoxIO-LLC/ja4/blob/main/python/test/testdata/single-packets.pcap.json#L53
