### PR TITLE
Bugs and Improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: test up down
+
+COMPOSE := docker compose -f test/docker-compose.yaml
+
+test:
+	lua test/unit_ja4h.lua
+
+up:
+	$(COMPOSE) up --build --watch
+
+down:
+	$(COMPOSE) down

--- a/ja4h.lua
+++ b/ja4h.lua
@@ -25,7 +25,7 @@ local function split_string(str, delimiter)
 end
 
 function starts_with(value, start)
-    return type(value) == 'string' and type(start) == 'string' and string.sub(value, 1, 1) == start
+    return type(value) == 'string' and type(start) == 'string' and string.sub(value, 1, #start) == start
 end
 
 local function http_version(txn)
@@ -44,14 +44,17 @@ local function method_code(txn)
 end
 
 -- TODO: 'connection' header missing for some reason?
+-- JA4H part a: count request headers EXCLUDING cookie and referer, as a fixed-width
+-- 2-digit value clamped at 99 (matches reference JA4H, e.g. ge11cn21enus...).
 local function header_count(txn)
-    local c = 0;
-    for i,v in pairs(split_string(txn.f:req_hdr_names(), ',')) do
+    local c = 0
+    for _, h in ipairs(split_string(txn.f:req_hdr_names(), ',')) do
+        h = string.lower(h)
         if (not starts_with(h, 'cookie') and h ~= 'referer') then
             c = c + 1
         end
     end
-    return c
+    return string.format('%02d', math.min(c, 99))
 end
 
 local function referer_is_set(txn)
@@ -78,19 +81,24 @@ local function accept_lang_beg(txn)
     end
     al = string.lower(al:gsub('%W',''))
     if (#al < 4) then
-        return string.rep('0', 4 - #al) .. al
+        return al .. string.rep('0', 4 - #al)
     end
     return string.sub(al, 1, 4)
 end
 
--- https://github.com/FoxIO-LLC/ja4/blob/main/python/ja4h.py#L27
-local function header_names_sorted(txn)
-    local h = split_string(txn.f:req_hdr_names(), ',')
-    table.sort(h)
-    if (not h) then
-        return ''
+-- https://github.com/FoxIO-LLC/ja4/blob/main/python/ja4h.py
+-- JA4H part b: hash of the request header names with cookie and referer removed
+-- (same filter as header_count), in the order they appear in the request.
+-- The reference implementation does not sort these names; only parts c/d are sorted.
+local function header_names(txn)
+    local names = {}
+    for _, h in ipairs(split_string(txn.f:req_hdr_names(), ',')) do
+        h = string.lower(h)
+        if (not starts_with(h, 'cookie') and h ~= 'referer') then
+            table.insert(names, h)
+        end
     end
-    return table.concat(h, ',')
+    return table.concat(names, ',')
 end
 
 -- https://github.com/FoxIO-LLC/ja4/blob/main/python/ja4h.py#L37
@@ -143,7 +151,7 @@ function fingerprint_ja4h(txn)
     local p5 = header_count(txn)
     local p6 = accept_lang_beg(txn)
 
-    local p7_pretty = header_names_sorted(txn)
+    local p7_pretty = header_names(txn)
     local p7 = truncated_sha256(txn, p7_pretty)
 
     local p8_pretty = cookie_names_sorted(txn)

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -48,7 +48,7 @@ RUN apk add --no-cache ca-certificates jemalloc && \
     rm -f /var/cache/apk/*
 
 FROM alpine:latest
-ENV HAPROXY_DOCKER_SRC_URL https://raw.githubusercontent.com/haproxytech/haproxy-docker-alpine/main/3.1/
+ENV HAPROXY_DOCKER_SRC_URL https://raw.githubusercontent.com/haproxytech/haproxy-docker-alpine/main/3.2
 RUN apk add --no-cache openssl zlib lua5.4-libs pcre2 jemalloc
 ADD --chmod=755 "${HAPROXY_DOCKER_SRC_URL}/docker-entrypoint.sh" '/docker-entrypoint.sh'
 ADD --chmod=644 "${HAPROXY_DOCKER_SRC_URL}/haproxy.cfg" '/usr/local/etc/haproxy/haproxy.cfg'

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
         - LICENSE.txt
         action: rebuild
     volumes:
-      - $PWD/ja4.lua:/tmp/haproxy_ja4h.lua
+      - $PWD/ja4h.lua:/tmp/haproxy_ja4h.lua:ro
       - $PWD/test/haproxy_example.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
     ports:
       - 127.0.0.1:6969:6969

--- a/test/unit_ja4h.lua
+++ b/test/unit_ja4h.lua
@@ -1,0 +1,118 @@
+#!/usr/bin/env lua
+-- Standalone unit tests for ../ja4h.lua.
+--
+-- Mocks the HAProxy Lua runtime (`core`, the `txn` fetch/converter objects) so the
+-- script can be exercised without HAProxy. The sha256 converter is mocked to identity,
+-- so no sha2.lua dependency is required and the JA4H "pretty" segments are asserted
+-- directly (parts a/b/c/d), which is where the behaviour under test lives.
+--
+-- Run:  lua test/unit_ja4h.lua   (exit code 0 = pass, 1 = fail)
+
+local here = (arg[0] or ''):match('(.*/)') or './'
+local SCRIPT = here .. '../ja4h.lua'
+
+-- The script calls core.register_action() at load time.
+core = { register_action = function() end }
+assert(loadfile(SCRIPT))()  -- defines globals: fingerprint_ja4h, starts_with
+
+local failures = 0
+local function check(name, cond, detail)
+  if cond then
+    print('  ok   - ' .. name)
+  else
+    failures = failures + 1
+    print('  FAIL - ' .. name .. (detail ~= nil and ('  [got: ' .. tostring(detail) .. ']') or ''))
+  end
+end
+
+-- Build a mock txn from a header-name list, a header value map, and optional cookies.
+-- cooks.__names is the comma-separated cookie-name list; cooks[name] is each value.
+local function make_txn(names, hdrs, cooks)
+  hdrs = hdrs or {}
+  local vars = {}
+  local f = {
+    method        = function() return 'GET' end,
+    req_ver       = function() return '1.1' end,
+    req_hdr_names = function() return names end,
+    req_hdr       = function(_, n) return hdrs[n] end,
+    req_fhdr      = function(_, n) return hdrs[n] end,
+    req_cook_names = function() return cooks and cooks.__names or nil end,
+    req_cook       = function(_, k) return cooks and cooks[k] or nil end,
+  }
+  local c = { digest = function(_, v) return v end, hex = function(_, v) return v end }
+  return { f = f, c = c, set_var = function(_, k, v) vars[k] = v end }, vars
+end
+
+-- Split on '_' preserving empty fields (p8/p9 are empty when there are no cookies).
+local function fields(raw)
+  local t, from = {}, 1
+  while true do
+    local s, e = raw:find('_', from, true)
+    if not s then t[#t + 1] = raw:sub(from); break end
+    t[#t + 1] = raw:sub(from, s - 1)
+    from = e + 1
+  end
+  return t
+end
+
+local function run(names, hdrs, cooks)
+  local txn, vars = make_txn(names, hdrs, cooks)
+  fingerprint_ja4h(txn)
+  return fields(vars['txn.fingerprint_ja4h_raw']), vars['txn.fingerprint_ja4h']
+end
+
+print('starts_with (prefix comparison):')
+check('multi-char prefix matches',      starts_with('cookie2', 'cookie') == true)
+check('non-matching prefix is false',   starts_with('referer', 'cookie') == false)
+check('single-char prefix still works', starts_with('c', 'c') == true)
+check('non-string returns false',       starts_with(nil, 'cookie') == false)
+
+print('part a - header count (no cookie/referer):')
+local p = run('host,user-agent,accept', {})
+check('count is fixed-width 2-digit', p[5] == '03', p[5])
+check('cookie flag is n',             p[3] == 'n', p[3])
+check('referer flag is n',            p[4] == 'n', p[4])
+
+print('cookie + referer present:')
+p = run('host,user-agent,accept,cookie,referer',
+        { cookie = 'sess=1', referer = 'http://example.test/' },
+        { __names = 'sess', sess = '1' })
+check('part a count excludes cookie & referer', p[5] == '03', p[5])
+check('part b names exclude cookie & referer',  p[7] == 'host,user-agent,accept', p[7])
+check('cookie flag is c',                        p[3] == 'c', p[3])
+check('referer flag is r',                       p[4] == 'r', p[4])
+check('part c has cookie names',                 p[8] == 'sess', p[8])
+check('part d has cookie name=value',            p[9] == 'sess=1', p[9])
+
+print('part b - header names keep request order:')
+p = run('user-agent,host,accept', {})
+check('names are not sorted alphabetically', p[7] == 'user-agent,host,accept', p[7])
+
+print('case-insensitive filtering:')
+p = run('Host,User-Agent,Cookie,Referer',
+        { Cookie = 'x=1', Referer = 'http://y/' }, { __names = 'x', x = '1' })
+check('mixed-case cookie/referer excluded from count', p[5] == '02', p[5])
+check('names lower-cased and filtered',                p[7] == 'host,user-agent', p[7])
+
+print('part a - accept-language padding:')
+p = run('host,accept-language', { ['accept-language'] = 'en' })
+check('short language is right-padded', p[6] == 'en00', p[6])
+p = run('host,accept-language', { ['accept-language'] = 'en-US' })
+check('four-char language is unpadded', p[6] == 'enus', p[6])
+p = run('host', {})
+check('missing language is 0000', p[6] == '0000', p[6])
+
+print('part a - count clamped to 99:')
+local many = {}
+for i = 1, 150 do many[#many + 1] = 'x-h' .. i end
+p = run(table.concat(many, ','), {})
+check('count clamps at 99', p[5] == '99', p[5])
+
+print('')
+if failures == 0 then
+  print('PASS: all ja4h unit tests passed')
+  os.exit(0)
+else
+  print('FAIL: ' .. failures .. ' check(s) failed')
+  os.exit(1)
+end


### PR DESCRIPTION
**Summary**

This PR corrects six defects in ja4h.lua that cause the generated fingerprint to diverge from the reference FoxIO JA4H specification, and adds a standalone unit-test suite to prevent regressions. Any request carrying a Cookie or Referer header — i.e. the vast majority of real browser traffic — currently produces a non-conformant fingerprint; short Accept-Language values and header-order hashing were also wrong. This restores parity with reference implementations.

**Changes**

1. `header_count` counted every header, including cookie/referer. The loop bound each header name to v but the filter tested `h`, an undefined global `(nil)`. `starts_with(nil, 'cookie')` is always false and `nil ~= 'referer'` is always true, so the guard never excluded anything. The loop now binds the header name `(for _, h in ipairs(...))` and lower-cases it before comparison.
2. starts_with only matched single-character prefixes. It compared `string.sub(value, 1, 1) == start`, i.e. the first character of value against the entire start string — so `starts_with('cookie…', 'cookie')` could never be true. Changed to string.sub(value, 1, #start) == start. This is the second, independent reason Cookie was never excluded, and is fixed alongside (1).
3. part a header count was not fixed-width. `header_count` returned a raw integer, yielding …cn7enus… for 7 headers instead of `…cn07enus…`, and three digits above 99 — producing variable-length, non-standard fingerprints. It now returns `string.format('%02d', math.min(c, 99))`.
4. part b hashed cookie/referer header names, and contained dead code. header_names_sorted hashed every name from `req_hdr_names()`, so the part b segment differed from reference JA4H for any request with a Cookie or Referer header. It now applies the same exclusion filter as `header_count`. The unreachable `if (not h)` guard `(following local h = split_string(...)`, which always returns a table) has been removed.
5. Short Accept-Language values were left-padded. After stripping non-word characters, a value shorter than 4 characters (e.g. `Accept-Language: en` → `en`) was padded on the left `(00en)`. The reference implementation pads the primary language on the right `(en00)`. Padding is now `al .. string.rep('0', 4 - #al)`. Four-character tags (`en-US` → `enus`) and a missing header (0000) are unchanged.
6. part b sorted header names before hashing. The JA4H spec hashes header names in the order they appear in the request; only parts c and d (cookie names/values) are sorted. Sorting collapsed client-distinguishing order information and produced hashes that do not match other JA4H implementations. Confirmed against [python/ja4h.py](https://github.com/FoxIO-LLC/ja4/blob/main/python/ja4h.py): `sha_encode(x['headers'])` is applied to the filtered list in wire order. Cookie sorting is unchanged.

Header names are lower-cased prior to filtering so exclusion is independent of the casing HAProxy reports. HAProxy’s `req.hdr_names()` itself returns lower-case names, so part b is hashed from lower-case names (the Python reference hashes wire casing).

**Impact / compatibility**

- Fingerprints for requests containing Cookie and/or Referer headers will change — this is the intended correction, aligning output with reference JA4H.
- Fingerprints for requests whose stripped Accept-Language is shorter than 4 characters will change (00en → en00).
- Fingerprints whose filtered header-name order is not already alphabetical will change (part b is no longer a sort of the name list).
- Consumers that persisted previously-generated values should expect a one-time shift.
- No configuration or API changes; the registered action, variable names (txn.fingerprint_ja4h, txn.fingerprint_ja4h_raw), and output format are unchanged.

**Testing**

Adds test/unit_ja4h.lua, a dependency-free suite that mocks the HAProxy Lua runtime (core, txn fetches/converters). The sha256 converter is mocked to identity, so the JA4H "pretty" segments (part a/b/c/d) are asserted directly with no sha2.lua dependency.

`lua test/unit_ja4h.lua      # exit 0 = pass, 1 = fail`
```
starts_with (prefix comparison):
  ok   - multi-char prefix matches
  ok   - non-matching prefix is false
  ok   - single-char prefix still works
  ok   - non-string returns false
part a - header count (no cookie/referer):
  ok   - count is fixed-width 2-digit
  ok   - cookie flag is n
  ok   - referer flag is n
cookie + referer present:
  ok   - part a count excludes cookie & referer
  ok   - part b names exclude cookie & referer
  ok   - cookie flag is c
  ok   - referer flag is r
  ok   - part c has cookie names
  ok   - part d has cookie name=value
part b - header names keep request order:
  ok   - names are not sorted alphabetically
case-insensitive filtering:
  ok   - mixed-case cookie/referer excluded from count
  ok   - names lower-cased and filtered
part a - accept-language padding:
  ok   - short language is right-padded
  ok   - four-char language is unpadded
  ok   - missing language is 0000
part a - count clamped to 99:
  ok   - count clamps at 99
```

**Coverage:**

- `starts_with` prefix matching (multi-char, non-match, single-char, non-string)
- part a count excludes cookie/referer, is two-digit, and clamps at 99
- part b name list excludes cookie/referer and preserves request order (not alphabetical)
- cookie/referer presence flags still resolve to `c/r` (control, proving exclusion is real and not masking absent headers)
- case-insensitive filtering of Cookie/Referer
- part a Accept-Language: right-pad when < 4 chars, first 4 chars when longer, 0000 when absent
- part c/d cookie name and name=value segments still populate

The suite passes on this branch and fails against the prior revision (e.g. part a "`5"` vs `"03"`, part b including `cookie,referer`, short language `00en `vs `en00`, part b alphabetically sorted), confirming it guards the fixed behavior.